### PR TITLE
FixtureServiceAwareInitializer > Also check for `ReferenceDictionary` trait

### DIFF
--- a/src/Context/Initializer/FixtureServiceAwareInitializer.php
+++ b/src/Context/Initializer/FixtureServiceAwareInitializer.php
@@ -43,7 +43,7 @@ final class FixtureServiceAwareInitializer implements ContextInitializer
      */
     public function initializeContext(Context $context)
     {
-        if (!$context instanceof FixtureServiceAwareContextInterface || !$this->usesReferenceDictionary($context)) {
+        if (!$context instanceof FixtureServiceAwareContextInterface && !$this->usesReferenceDictionary($context)) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes 
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

The `FixtureServiceAwareInitializer` was never able to check for the `BehatExtension\DoctrineDataFixturesExtension\Context\ReferenceDictionary` trait because it already returns when `$context instanceof FixtureServiceAwareContextInterface` is `false`. 

Would be great to have this merged and tagged 🙏 