### PR TITLE
Replace anonymous extension class with real class

### DIFF
--- a/src/Bundle/BehatDoctrineDataFixturesExtension.php
+++ b/src/Bundle/BehatDoctrineDataFixturesExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2018 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace BehatExtension\DoctrineDataFixturesExtension\Bundle;
+
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+final class BehatDoctrineDataFixturesExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $container->setAlias('doctrine.fixtures.loader.alias', new Alias('doctrine.fixtures.loader', true));
+    }
+
+    public function getAlias()
+    {
+        return 'behat_doctrine_data_fixtures_extension';
+    }
+}

--- a/src/Bundle/BehatDoctrineDataFixturesExtensionBundle.php
+++ b/src/Bundle/BehatDoctrineDataFixturesExtensionBundle.php
@@ -13,25 +13,12 @@ declare(strict_types=1);
 
 namespace BehatExtension\DoctrineDataFixturesExtension\Bundle;
 
-use Symfony\Component\DependencyInjection\Alias;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class BehatDoctrineDataFixturesExtensionBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtensionClass()
     {
-        return new class() extends Extension {
-            public function load(array $configs, ContainerBuilder $container)
-            {
-                $container->setAlias('doctrine.fixtures.loader.alias', new Alias('doctrine.fixtures.loader', true));
-            }
-
-            public function getAlias()
-            {
-                return 'behat_doctrine_data_fixtures_extension';
-            }
-        };
+        return BehatDoctrineDataFixturesExtension::class;
     }
 }


### PR DESCRIPTION
This doesn't work properly on PHP 7.4 for some reason.

https://github.com/symfony/symfony/issues/34613

| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes, https://github.com/symfony/symfony/issues/34613
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no

